### PR TITLE
Support data overwriting

### DIFF
--- a/intelhex_class/intelhexclass.cpp.bak
+++ b/intelhex_class/intelhexclass.cpp.bak
@@ -250,22 +250,6 @@ void intelhex::addError(string errorMessage)
 }
 
 /*******************************************************************************
-* Overwrite data at a given location
-*******************************************************************************/
-void intelhex::overwriteData(unsigned char data, unsigned long address)
-{	
-    map<unsigned long, unsigned char>::iterator ihIterator;
-
-	ihIterator = ihContent.find(address);
-	if(ihIterator != ihContent.end())
-	{
-		ihContent.erase(address);
-	}
-
-	ihReturn = ihContent.insert(pair<unsigned long,unsigned char>(address, data)); 
-}
-
-/*******************************************************************************
 * Decodes a data record read in from a file
 *******************************************************************************/
 void intelhex::decodeDataRecord(unsigned char recordLength,
@@ -886,11 +870,11 @@ ostream& operator<<(ostream& dataOut, intelhex& ihLocal)
             thisRecord = ":02000004";
             checksum = 0x02 + 0x04;
             
-			dataByte = static_cast<unsigned char>((addressOffset >> 8) & 0xFF);
+            dataByte = static_cast<unsigned char>(addressOffset & 0xFF);
             checksum += dataByte;
             thisRecord += ihLocal.ucToHexString(dataByte);
             
-            dataByte = static_cast<unsigned char>(addressOffset & 0xFF);
+            dataByte = static_cast<unsigned char>((addressOffset >> 8) & 0xFF);
             checksum += dataByte;
             thisRecord += ihLocal.ucToHexString(dataByte);
             
@@ -905,11 +889,11 @@ ostream& operator<<(ostream& dataOut, intelhex& ihLocal)
             thisRecord = ":02000002";
             checksum = 0x02 + 0x02;
             
-            dataByte = static_cast<unsigned char>((addressOffset >> 8) & 0xFF);
+            dataByte = static_cast<unsigned char>(addressOffset & 0xFF);
             checksum += dataByte;
             thisRecord += ihLocal.ucToHexString(dataByte);
             
-            dataByte = static_cast<unsigned char>(addressOffset & 0xFF);
+            dataByte = static_cast<unsigned char>((addressOffset >> 8) & 0xFF);
             checksum += dataByte;
             thisRecord += ihLocal.ucToHexString(dataByte);
             
@@ -948,11 +932,11 @@ ostream& operator<<(ostream& dataOut, intelhex& ihLocal)
                     thisRecord = ":02000004";
                     checksum = 0x02 + 0x04;
                     
-					dataByte = static_cast<unsigned char>((addressOffset >> 8) & 0xFF);
+                    dataByte = static_cast<unsigned char>(addressOffset & 0xFF);
                     checksum += dataByte;
                     thisRecord += ihLocal.ucToHexString(dataByte);
                     
-					dataByte = static_cast<unsigned char>(addressOffset & 0xFF);
+                    dataByte = static_cast<unsigned char>((addressOffset >> 8) & 0xFF);
                     checksum += dataByte;
                     thisRecord += ihLocal.ucToHexString(dataByte);
                     
@@ -978,11 +962,11 @@ ostream& operator<<(ostream& dataOut, intelhex& ihLocal)
                     thisRecord = ":02000002";
                     checksum = 0x02 + 0x02;
                     
-					dataByte = static_cast<unsigned char>((addressOffset >> 8) & 0xFF);
+                    dataByte = static_cast<unsigned char>(addressOffset & 0xFF);
                     checksum += dataByte;
                     thisRecord += ihLocal.ucToHexString(dataByte);
                     
-                    dataByte = static_cast<unsigned char>(addressOffset & 0xFF);
+                    dataByte = static_cast<unsigned char>((addressOffset >> 8) & 0xFF);
                     checksum += dataByte;
                     thisRecord += ihLocal.ucToHexString(dataByte);
                     


### PR DESCRIPTION
overwriteData() method added
Bugfix on generating HEX file. Byte order of linear address was
wrong(?!)