### PR TITLE
- intelhex::endOfData should return false when the last byte of the

### DIFF
--- a/intelhex_class/intelhexclass.cpp
+++ b/intelhex_class/intelhexclass.cpp
@@ -479,7 +479,9 @@ istream& operator>>(istream& dataIn, intelhex& ihLocal)
                         if (ihLocal.verbose == true)
                         {
                             cout << "Data Record begining @ 0x" << 
-                                      ihLocal.ulToHexString(loadOffset) << endl;
+                                    ihLocal.ulToHexString(loadOffset) <<
+                                    " size 0x" <<
+                                    ihLocal.ulToHexString(recordLength) << endl;
                         }
                         break;
                     

--- a/intelhex_class/intelhexclass.h
+++ b/intelhex_class/intelhexclass.h
@@ -615,15 +615,7 @@ class intelhex {
             
             if (!ihContent.empty())
             {
-                map<unsigned long, unsigned char>::iterator it \
-                    = ihContent.end();
-				
-                --it;
-
-                if (it != ihIterator)
-                {
-                    result = false;
-                }
+                return ihIterator == ihContent.end();
             }
             return result;
         }


### PR DESCRIPTION
hex file was not read
- Improved verbose logging with displaying the records length